### PR TITLE
Deleted exclusive flag for CocoaPods v1.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -8,11 +8,11 @@ post_install do |installer|
     end
 end
 
-target 'MODE-iOSSDK_Example', :exclusive => true do
+target 'MODE-iOSSDK_Example' do
   pod "MODE-iOSSDK", :path => "../"
 end
 
-target 'MODE-iOSSDK_Tests', :exclusive => true do
+target 'MODE-iOSSDK_Tests' do
   pod "MODE-iOSSDK", :path => "../"
 
   pod 'Kiwi'


### PR DESCRIPTION
## summary

`:exclusive => true` flag is removed in CocoaPods v1.x

http://blog.cocoapods.org/CocoaPods-1.0-Migration-Guide/